### PR TITLE
fix: explicitly set IRB version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,31 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.0', '3.1', '3.2']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Install gems
+      run: bundle install
+    - name: Run tests
+      run: bundle exec ruby -Ilib bin/saikuro --cyclo --token --input_directory tests

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/lib/saikuro.rb
+++ b/lib/saikuro.rb
@@ -41,6 +41,8 @@
 # Morton Jonuschat
 # Antoine Toulme (antoine@lunar-ocean.com)
 
+require 'rubygems'
+gem 'irb', '=1.1.1'
 require 'irb/ruby-lex'
 require 'yaml'
 

--- a/saikuro.gemspec
+++ b/saikuro.gemspec
@@ -54,4 +54,6 @@ spec = Gem::Specification.new do |s|
   s.executables = ['saikuro']
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc"]
+  s.add_dependency 'irb', '=1.1.1'
+  s.add_dependency 'e2mmap'
 end


### PR DESCRIPTION
Hello,

This pull request has the following changes:

* update dependencies
  * explicitly set IRB version (irb 1.2.0 or later doesn't have `RubyToken`)
  * add e2mmap
* add GitHub workflow
* add Gemfile

Thank you,